### PR TITLE
Fix maternal routes and add more output

### DIFF
--- a/src/Infrastructures/http/_test/maternal.test.js
+++ b/src/Infrastructures/http/_test/maternal.test.js
@@ -16,7 +16,7 @@ describe("HTTP server - maternal", () => {
     await UsersTableTestHelper.cleanTable();
   });
 
-  describe("when POST /api/v1/maternal", () => {
+  describe("when POST /api/v1/maternals", () => {
     it("should response 201 and persisted maternal", async () => {
       // Arrange
       const requestPayload = {
@@ -44,7 +44,7 @@ describe("HTTP server - maternal", () => {
 
       const response = await server.inject({
         method: "POST",
-        url: "/api/v1/maternal",
+        url: "/api/v1/maternals",
         payload: { ...requestPayload, userId: id },
       });
 
@@ -69,7 +69,7 @@ describe("HTTP server - maternal", () => {
       // Action
       const response = await server.inject({
         method: "POST",
-        url: "/api/v1/maternal",
+        url: "/api/v1/maternals",
         payload: requestPayload,
       });
 
@@ -80,7 +80,7 @@ describe("HTTP server - maternal", () => {
     });
   });
 
-  describe("when POST /api/v1/maternal/user", () => {
+  describe("when POST /api/v1/maternals/user", () => {
     it("should response 200 and presist user and maternal", async () => {
       // Arrange
       const useCasePayload = {
@@ -108,7 +108,7 @@ describe("HTTP server - maternal", () => {
       // Action
       const response = await server.inject({
         method: "POST",
-        url: "/api/v1/maternal/user",
+        url: "/api/v1/maternals/user",
         payload: useCasePayload,
       });
 
@@ -136,7 +136,7 @@ describe("HTTP server - maternal", () => {
       // Action
       const response = await server.inject({
         method: "POST",
-        url: "/api/v1/maternal/user",
+        url: "/api/v1/maternals/user",
         payload: requestPayload,
       });
 
@@ -173,7 +173,7 @@ describe("HTTP server - maternal", () => {
       // Action
       const response = await server.inject({
         method: "POST",
-        url: "/api/v1/maternal/user",
+        url: "/api/v1/maternals/user",
         payload: useCasePayload,
       });
 
@@ -184,7 +184,7 @@ describe("HTTP server - maternal", () => {
     });
   });
 
-  describe("when GET /api/v1/maternal", () => {
+  describe("when GET /api/v1/maternals", () => {
     it("should response 200 and show all maternal", async () => {
       // Arrange
       const userId = "user-123";
@@ -211,7 +211,7 @@ describe("HTTP server - maternal", () => {
       // Action
       const response = await server.inject({
         method: "GET",
-        url: "/api/v1/maternal",
+        url: "/api/v1/maternals",
       });
 
       // Assert

--- a/src/Infrastructures/repository/MaternalRepositoryPostgres.js
+++ b/src/Infrastructures/repository/MaternalRepositoryPostgres.js
@@ -83,6 +83,7 @@ class MaternalRepositoryPostgres extends MaternalRepository {
         "users.name as name",
         "users.nik as nik",
         "maternal_histories.maternal_status as last_maternal_status",
+        "maternal_histories.id as last_maternal_history_id",
         "maternals.user_id",
       ])
       .paginate();

--- a/src/Infrastructures/repository/_test/MaternalRepositoryPostgres.test.js
+++ b/src/Infrastructures/repository/_test/MaternalRepositoryPostgres.test.js
@@ -200,6 +200,7 @@ describe("MaternalRepositoryPostgres", () => {
       expect(maternals).toHaveLength(1);
       expect(maternals[0].id).toStrictEqual("maternal-123");
       expect(maternals[0]).toHaveProperty("last_maternal_status");
+      expect(maternals[0]).toHaveProperty("last_maternal_history_id");
     });
 
     it("should return empty array when no maternal found", async () => {

--- a/src/Interfaces/http/api/maternal/routes.js
+++ b/src/Interfaces/http/api/maternal/routes.js
@@ -1,17 +1,17 @@
 const routes = (handler) => [
   {
     method: "POST",
-    path: "/api/v1/maternal",
+    path: "/api/v1/maternals",
     handler: handler.postMaternalHandler,
   },
   {
     method: "POST",
-    path: "/api/v1/maternal/user",
+    path: "/api/v1/maternals/user",
     handler: handler.postMaternalUserHandler,
   },
   {
     method: "GET",
-    path: "/api/v1/maternal",
+    path: "/api/v1/maternals",
     handler: handler.getMaternalHandler,
   },
 ];


### PR DESCRIPTION
Routes should be use `/api/v1/maternals` instead of `/api/v1/maternal`

Add more output to /api/v1/maternals
```
...
last_maternal_history_id: String
...
```