### PR TITLE
Fix maternals class constructor singleton

### DIFF
--- a/src/Infrastructures/queries/BaseQuery.js
+++ b/src/Infrastructures/queries/BaseQuery.js
@@ -46,6 +46,23 @@ class BaseQuery {
 
     const results = await this._pool.query(query);
 
+    // reset this class state
+    this._finalObject = {
+      select: "*",
+      where: "",
+      values: [],
+      paginate: "",
+      joins: "",
+      currentIndex: 0,
+    };
+
+    this.paginationMeta = {
+      size: 0,
+      perPage: 0,
+      currentPage: 0,
+      totalPages: 0,
+    };
+
     return {
       data: results.rows,
       meta: this.paginationMeta,

--- a/src/Infrastructures/queries/BaseQuery.js
+++ b/src/Infrastructures/queries/BaseQuery.js
@@ -56,13 +56,6 @@ class BaseQuery {
       currentIndex: 0,
     };
 
-    this.paginationMeta = {
-      size: 0,
-      perPage: 0,
-      currentPage: 0,
-      totalPages: 0,
-    };
-
     return {
       data: results.rows,
       meta: this.paginationMeta,

--- a/src/Infrastructures/queries/BaseQuery.js
+++ b/src/Infrastructures/queries/BaseQuery.js
@@ -56,6 +56,9 @@ class BaseQuery {
       currentIndex: 0,
     };
 
+    this._page = 1;
+    this._perPage = 100;
+
     return {
       data: results.rows,
       meta: this.paginationMeta,

--- a/src/Infrastructures/queries/MaternalQuery.js
+++ b/src/Infrastructures/queries/MaternalQuery.js
@@ -15,10 +15,10 @@ class MaternalQuery extends BaseQuery {
   }
 
   joinByLastMaternalStatus() {
-    return `INNER JOIN (
+    return `LEFT JOIN (
       SELECT maternal_id, MAX(created_at) as latest_created_at FROM maternal_histories GROUP BY maternal_id        
     ) latest_histories ON maternals.id = latest_histories.maternal_id
-    INNER JOIN maternal_histories ON maternal_histories.maternal_id = latest_histories.maternal_id AND maternal_histories.created_at = latest_histories.latest_created_at`;
+    LEFT JOIN maternal_histories ON maternal_histories.maternal_id = latest_histories.maternal_id AND maternal_histories.created_at = latest_histories.latest_created_at`;
   }
 }
 

--- a/src/Infrastructures/queries/_test/MaternalQuery.test.js
+++ b/src/Infrastructures/queries/_test/MaternalQuery.test.js
@@ -122,6 +122,33 @@ describe("MaternalQuery", () => {
     });
   });
 
+  it("should return maternal data even when maternal history not present", async () => {
+    // Arrange
+    const userId = "user-123";
+    const maternalId = "maternal-123";
+    const maternalQuery = new MaternalQuery({ pool });
+
+    await UsersTableTestHelper.addUser({ id: userId, name: "user" });
+    await MaternalTableTestHelper.addMaternal({ id: maternalId, userId });
+
+    // Action
+    const queryResult = await maternalQuery
+      .joins(["users", "lastMaternalStatus"])
+      .selects([
+        "maternals.id",
+        "users.name",
+        "maternal_histories.maternal_status as last_maternal_status",
+      ])
+      .paginate();
+
+    // Assert
+    expect(queryResult.data).toHaveLength(1);
+
+    expect(queryResult.data[0]).toHaveProperty("name");
+    expect(queryResult.data[0]).toHaveProperty("last_maternal_status");
+    expect(queryResult.data[0].last_maternal_status).toBeNull();
+  });
+
   it("should return maternal data correctly when combined with other query", async () => {
     // Arrange
     const userId = "user-123";


### PR DESCRIPTION
- Some error when accessing maternals GET API because of BaseQuery class counted as Singletone on Javascript, It do not create new object class because of inheritence, so the constructor value not being reinitiated
- Add left join for maternal histories, so even maternal still have not done its pemeriksaan it will shown in the dashboard